### PR TITLE
Update lnc-web to v0.2.0-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@babel/core": "7.16.0",
-        "@lightninglabs/lnc-web": "0.1.12-alpha",
+        "@lightninglabs/lnc-web": "0.2.0-alpha",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.3",
         "@svgr/webpack": "6.5.0",
         "@testing-library/jest-dom": "5.16.4",
@@ -2886,11 +2886,57 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "devOptional": true
     },
-    "node_modules/@lightninglabs/lnc-web": {
-      "version": "0.1.12-alpha",
-      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.1.12-alpha.tgz",
-      "integrity": "sha512-6cvDM5bdDdiEoXRZlDYWBlXGmCc8cSCXCnz3JFEf9iGBPgP+6oMG9Ds+O/7HuD8elX1dhGx/BGo998jNJqn1Hg==",
+    "node_modules/@lightninglabs/lnc-core": {
+      "version": "0.2.0-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.0-alpha.tgz",
+      "integrity": "sha512-tX9ndYGJ9+8VL5GvMDveBhIuRLBlbRr9kuZXxEPwFDm5UaAzc9syF7119+6e0Ctx0cDCSGG+Y7YirNaTD1xCuA==",
       "dependencies": {
+        "node-polyfill-webpack-plugin": "1.1.4"
+      }
+    },
+    "node_modules/@lightninglabs/lnc-core/node_modules/node-polyfill-webpack-plugin": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-1.1.4.tgz",
+      "integrity": "sha512-Z0XTKj1wRWO8o/Vjobsw5iOJCN+Sua3EZEUc2Ziy9CyVvmHKu6o+t4gUH9GOE0czyPR94LI6ZCV/PpcM8b5yow==",
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^6.0.3",
+        "console-browserify": "^1.2.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.12.0",
+        "domain-browser": "^4.19.0",
+        "events": "^3.3.0",
+        "filter-obj": "^2.0.2",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "punycode": "^2.1.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.3.0",
+        "timers-browserify": "^2.0.12",
+        "tty-browserify": "^0.0.1",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": ">=5"
+      }
+    },
+    "node_modules/@lightninglabs/lnc-web": {
+      "version": "0.2.0-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.2.0-alpha.tgz",
+      "integrity": "sha512-gWfCZY3waqbeQeNh25/vPhvRGZtMHWriiqP7c4w538LMq1psCW1/VwQ6dcwvlkpFWGaT6QMATHpT/G+hm6IT2A==",
+      "dependencies": {
+        "@lightninglabs/lnc-core": "0.2.0-alpha",
         "crypto-js": "4.1.1"
       }
     },
@@ -5157,9 +5203,9 @@
       }
     },
     "node_modules/babel-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -12139,9 +12185,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -14814,9 +14860,9 @@
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-      "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -14943,25 +14989,14 @@
       }
     },
     "node_modules/recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "dependencies": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/redent": {
@@ -19787,11 +19822,53 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "devOptional": true
     },
-    "@lightninglabs/lnc-web": {
-      "version": "0.1.12-alpha",
-      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.1.12-alpha.tgz",
-      "integrity": "sha512-6cvDM5bdDdiEoXRZlDYWBlXGmCc8cSCXCnz3JFEf9iGBPgP+6oMG9Ds+O/7HuD8elX1dhGx/BGo998jNJqn1Hg==",
+    "@lightninglabs/lnc-core": {
+      "version": "0.2.0-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.0-alpha.tgz",
+      "integrity": "sha512-tX9ndYGJ9+8VL5GvMDveBhIuRLBlbRr9kuZXxEPwFDm5UaAzc9syF7119+6e0Ctx0cDCSGG+Y7YirNaTD1xCuA==",
       "requires": {
+        "node-polyfill-webpack-plugin": "1.1.4"
+      },
+      "dependencies": {
+        "node-polyfill-webpack-plugin": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-1.1.4.tgz",
+          "integrity": "sha512-Z0XTKj1wRWO8o/Vjobsw5iOJCN+Sua3EZEUc2Ziy9CyVvmHKu6o+t4gUH9GOE0czyPR94LI6ZCV/PpcM8b5yow==",
+          "requires": {
+            "assert": "^2.0.0",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^6.0.3",
+            "console-browserify": "^1.2.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "^3.12.0",
+            "domain-browser": "^4.19.0",
+            "events": "^3.3.0",
+            "filter-obj": "^2.0.2",
+            "https-browserify": "^1.0.0",
+            "os-browserify": "^0.3.0",
+            "path-browserify": "^1.0.1",
+            "process": "^0.11.10",
+            "punycode": "^2.1.1",
+            "querystring-es3": "^0.2.1",
+            "readable-stream": "^3.6.0",
+            "stream-browserify": "^3.0.0",
+            "stream-http": "^3.2.0",
+            "string_decoder": "^1.3.0",
+            "timers-browserify": "^2.0.12",
+            "tty-browserify": "^0.0.1",
+            "url": "^0.11.0",
+            "util": "^0.12.4",
+            "vm-browserify": "^1.1.2"
+          }
+        }
+      }
+    },
+    "@lightninglabs/lnc-web": {
+      "version": "0.2.0-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-web/-/lnc-web-0.2.0-alpha.tgz",
+      "integrity": "sha512-gWfCZY3waqbeQeNh25/vPhvRGZtMHWriiqP7c4w538LMq1psCW1/VwQ6dcwvlkpFWGaT6QMATHpT/G+hm6IT2A==",
+      "requires": {
+        "@lightninglabs/lnc-core": "0.2.0-alpha",
         "crypto-js": "4.1.1"
       }
     },
@@ -21436,9 +21513,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -26522,9 +26599,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -28329,9 +28406,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "loader-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+          "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -28427,21 +28504,11 @@
       }
     },
     "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "requires": {
-        "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+        "minimatch": "^3.0.5"
       }
     },
     "redent": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.16.0",
-    "@lightninglabs/lnc-web": "0.1.12-alpha",
+    "@lightninglabs/lnc-web": "0.2.0-alpha",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.3",
     "@svgr/webpack": "6.5.0",
     "@testing-library/jest-dom": "5.16.4",

--- a/src/hooks/useLNC.ts
+++ b/src/hooks/useLNC.ts
@@ -2,10 +2,7 @@ import { useCallback } from 'react';
 import LNC from '@lightninglabs/lnc-web';
 
 // create a singleton instance of LNC that will live for the lifetime of the app
-const lnc = new LNC({
-    wasmClientCode: 'wasm-client.wasm'
-    // wasmClientCode: 'https://storage.googleapis.com/lnc-apollo/wasm-client.wasm'
-});
+const lnc = new LNC({});
 
 /**
  * A hook that exposes a single LNC instance of LNC to all component that need it.


### PR DESCRIPTION
With this new release of lnc-web, we no longer have to run a custom lnc-web WASM in our app that has the proper permissions for sending payments.

TODO
- [x] delete CDN instance